### PR TITLE
Fiks labs

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,20 +9,20 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "axios": "1.7.2",
+                "axios": "1.7.7",
                 "body-parser": "1.20.2",
                 "cors": "2.8.5",
                 "dotenv": "16.4.5",
-                "express": "4.19.2",
+                "express": "4.20.0",
                 "express-async-handler": "1.2.0",
-                "express-http-proxy": "2.0.0",
+                "express-http-proxy": "2.1.1",
                 "express-session": "1.18.0",
                 "helmet": "7.1.0",
-                "http-proxy-middleware": "3.0.0",
+                "http-proxy-middleware": "3.0.2",
                 "openid-client": "5.6.5",
                 "passport": "0.7.0",
                 "tunnel": "0.0.6",
-                "winston": "3.13.0"
+                "winston": "3.14.2"
             }
         },
         "node_modules/@colors/colors": {
@@ -43,15 +43,20 @@
             }
         },
         "node_modules/@types/http-proxy": {
-            "version": "1.17.11",
-            "license": "MIT",
+            "version": "1.17.15",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
+            "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/node": {
-            "version": "20.3.1",
-            "license": "MIT"
+            "version": "22.5.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+            "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+            "dependencies": {
+                "undici-types": "~6.19.2"
+            }
         },
         "node_modules/@types/triple-beam": {
             "version": "1.3.5",
@@ -82,9 +87,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -132,12 +137,18 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.5",
-            "license": "MIT",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.1",
-                "set-function-length": "^1.1.1"
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -244,15 +255,19 @@
             "license": "MIT"
         },
         "node_modules/define-data-property": {
-            "version": "1.1.1",
-            "license": "MIT",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dependencies": {
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/delayed-stream": {
@@ -303,6 +318,25 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es6-promise": {
             "version": "4.2.8",
             "license": "MIT"
@@ -313,7 +347,8 @@
         },
         "node_modules/etag": {
             "version": "1.8.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -323,36 +358,36 @@
             "license": "MIT"
         },
         "node_modules/express": {
-            "version": "4.19.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
+            "integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.2",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
                 "finalhandler": "1.2.0",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.10",
                 "proxy-addr": "~2.0.7",
                 "qs": "6.11.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.0",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -368,8 +403,9 @@
             "license": "MIT"
         },
         "node_modules/express-http-proxy": {
-            "version": "2.0.0",
-            "license": "MIT",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-2.1.1.tgz",
+            "integrity": "sha512-4aRQRqDQU7qNPV5av0/hLcyc0guB9UP71nCYrQEYml7YphTo8tmWf3nDZWdTJMMjFikyz9xKXaURor7Chygdwg==",
             "dependencies": {
                 "debug": "^3.0.1",
                 "es6-promise": "^4.1.1",
@@ -408,6 +444,51 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
             "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+        },
+        "node_modules/express/node_modules/body-parser": {
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.4.1",
+                "qs": "6.13.0",
+                "raw-body": "2.5.2",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/express/node_modules/body-parser/node_modules/qs": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "dependencies": {
+                "side-channel": "^1.0.6"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/express/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/fecha": {
             "version": "4.2.3",
@@ -485,26 +566,33 @@
         },
         "node_modules/fresh": {
             "version": "0.5.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.2",
-            "license": "MIT",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
                 "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -512,7 +600,8 @@
         },
         "node_modules/gopd": {
             "version": "1.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
             "dependencies": {
                 "get-intrinsic": "^1.1.3"
             },
@@ -521,18 +610,20 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.1",
-            "license": "MIT",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dependencies": {
-                "get-intrinsic": "^1.2.2"
+                "es-define-property": "^1.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-proto": {
-            "version": "1.0.1",
-            "license": "MIT",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -542,7 +633,8 @@
         },
         "node_modules/has-symbols": {
             "version": "1.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -551,8 +643,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.0",
-            "license": "MIT",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -594,27 +687,27 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
-            "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.2.tgz",
+            "integrity": "sha512-fBLFpmvDzlxdckwZRjM0wWtwDZ4KBtQ8NFqhrFKoEtK4myzuiumBuNTxD+F4cVbXfOZljIbrynmvByofDzT7Ag==",
             "dependencies": {
-                "@types/http-proxy": "^1.17.10",
-                "debug": "^4.3.4",
+                "@types/http-proxy": "^1.17.15",
+                "debug": "^4.3.6",
                 "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.5"
+                "is-glob": "^4.0.3",
+                "is-plain-object": "^5.0.0",
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/http-proxy-middleware/node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -624,11 +717,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/http-proxy-middleware/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
@@ -680,14 +768,12 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "license": "MIT",
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-stream": {
@@ -746,8 +832,12 @@
             }
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
-            "license": "MIT"
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -757,10 +847,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "license": "MIT",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -769,7 +860,8 @@
         },
         "node_modules/mime": {
             "version": "1.6.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "bin": {
                 "mime": "cli.js"
             },
@@ -901,15 +993,17 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.7",
-            "license": "MIT"
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         },
         "node_modules/pause": {
             "version": "0.0.1"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "engines": {
                 "node": ">=8.6"
             },
@@ -954,7 +1048,8 @@
         },
         "node_modules/range-parser": {
             "version": "1.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1020,8 +1115,9 @@
             "license": "MIT"
         },
         "node_modules/send": {
-            "version": "0.18.0",
-            "license": "MIT",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -1042,8 +1138,9 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.15.0",
-            "license": "MIT",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
+            "integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
             "dependencies": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
@@ -1054,14 +1151,40 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/set-function-length": {
-            "version": "1.1.1",
-            "license": "MIT",
+        "node_modules/serve-static/node_modules/send": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
             "dependencies": {
-                "define-data-property": "^1.1.1",
-                "get-intrinsic": "^1.2.1",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "has-property-descriptors": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1072,12 +1195,17 @@
             "license": "ISC"
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "license": "MIT",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -1170,6 +1298,11 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "license": "MIT",
@@ -1197,15 +1330,15 @@
             }
         },
         "node_modules/winston": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
-            "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+            "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
             "dependencies": {
                 "@colors/colors": "^1.6.0",
                 "@dabh/diagnostics": "^2.0.2",
                 "async": "^3.2.3",
                 "is-stream": "^2.0.0",
-                "logform": "^2.4.0",
+                "logform": "^2.6.0",
                 "one-time": "^1.0.0",
                 "readable-stream": "^3.4.0",
                 "safe-stable-stringify": "^2.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -3,19 +3,19 @@
     "version": "1.0.0",
     "license": "MIT",
     "dependencies": {
-        "axios": "1.7.2",
+        "axios": "1.7.7",
         "body-parser": "1.20.2",
         "cors": "2.8.5",
         "dotenv": "16.4.5",
-        "express": "4.19.2",
+        "express": "4.20.0",
         "express-async-handler": "1.2.0",
-        "express-http-proxy": "2.0.0",
+        "express-http-proxy": "2.1.1",
         "express-session": "1.18.0",
         "helmet": "7.1.0",
-        "http-proxy-middleware": "3.0.0",
+        "http-proxy-middleware": "3.0.2",
         "openid-client": "5.6.5",
         "passport": "0.7.0",
         "tunnel": "0.0.6",
-        "winston": "3.13.0"
+        "winston": "3.14.2"
     }
 }

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -40,16 +40,18 @@ async function startLabs(server) {
             createProxyMiddleware({
                 target: 'http://tiltak-refusjon-api-labs',
                 changeOrigin: true,
-                onProxyReq: (proxyReq, req, res, options) => {
-                    const cookies = req.headers?.cookie?.split(';');
-                    const cookieWithFakeToken = cookies?.filter((c) => c.includes('tokenx-token'));
-                    if (!cookieWithFakeToken?.length) {
-                        res.writeHead(401);
-                        res.end();
-                        return;
-                    }
-                    const accessToken = cookieWithFakeToken[0].split('=')[1];
-                    proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
+                on: {
+                    proxyReq: (proxyReq, req, res, options) => {
+                        const cookies = req.headers?.cookie?.split(';');
+                        const cookieWithFakeToken = cookies?.filter((c) => c.includes('tokenx-token'));
+                        if (!cookieWithFakeToken?.length) {
+                            res.writeHead(401);
+                            res.end();
+                            return;
+                        }
+                        const accessToken = cookieWithFakeToken[0].split('=')[1];
+                        proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
+                    },
                 },
             })
         );

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -18,16 +18,16 @@ async function startLabs(server) {
         server.use(express.urlencoded({ extended: true }));
 
         // setup sane defaults for CORS and HTTP headers
-        // server.use(helmet());
-        // server.use(
-        //     cors({
-        //         allowedHeaders: ['sessionId', 'Content-Type'],
-        //         exposedHeaders: ['sessionId'],
-        //         origin: '*',
-        //         methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-        //         preflightContinue: false,
-        //     })
-        // );
+        server.use(helmet());
+        server.use(
+            cors({
+                allowedHeaders: ['sessionId', 'Content-Type'],
+                exposedHeaders: ['sessionId'],
+                origin: '*',
+                methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+                preflightContinue: false,
+            })
+        );
 
         // setup routes
         server.get('/isAlive', (req, res) => res.send('Alive'));

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -18,7 +18,7 @@ async function startLabs(server) {
         server.use(express.urlencoded({ extended: true }));
 
         // setup sane defaults for CORS and HTTP headers
-        //server.use(helmet());
+        // server.use(helmet());
         server.use(
             cors({
                 allowedHeaders: ['sessionId', 'Content-Type'],

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -35,39 +35,33 @@ async function startLabs(server) {
 
         server.use(express.static(path.join(__dirname, '../build')));
 
-        const restream = (proxyReq, req, res, options) => {
-            if (req.body) {
-                let bodyData = JSON.stringify(req.body);
-                proxyReq.setHeader('Content-Type', 'application/json');
-                proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-                proxyReq.write(bodyData);
-            }
-        };
-
         server.use(
             '/api',
             createProxyMiddleware({
                 target: 'http://tiltak-refusjon-api-labs',
-                onProxyReq: restream,
+                onProxyReq: (proxyReq, req, res, options) => {
+                    const cookies = req.headers?.cookie?.split(';');
+                    const cookieWithFakeToken = cookies?.filter((c) => c === 'tokenx-token');
+                    if (!cookieWithFakeToken?.length) {
+                        res.writeHead(401);
+                        res.end();
+                        return;
+                    }
+                    const accessToken = cookieWithFakeToken[0].split('=')[1];
+                    proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
+                    if (req.body) {
+                        let bodyData = JSON.stringify(req.body);
+                        proxyReq.setHeader('Content-Type', 'application/json');
+                        proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+                        proxyReq.write(bodyData);
+                    }
+                },
                 changeOrigin: true,
                 proxyTimeout: 30000,
                 secure: true,
                 logLevel: 'info',
                 onError: (err, req, res) => {
                     logger.error('error in proxy', err, req, res);
-                },
-                configure: (proxy) => {
-                    proxy.on('proxyReq', (proxyReq, req, res) => {
-                        const cookies = req.headers?.cookie?.split(';');
-                        const cookieWithFakeToken = cookies?.filter((c) => c === 'tokenx-token');
-                        if (!cookieWithFakeToken?.length) {
-                            res.writeHead(401);
-                            res.end();
-                            return;
-                        }
-                        const accessToken = cookieWithFakeToken[0].split('=')[1];
-                        proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
-                    });
                 },
             })
         );

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -39,9 +39,10 @@ async function startLabs(server) {
             '/api',
             createProxyMiddleware({
                 target: 'http://tiltak-refusjon-api-labs',
+                changeOrigin: true,
                 onProxyReq: (proxyReq, req, res, options) => {
                     const cookies = req.headers?.cookie?.split(';');
-                    const cookieWithFakeToken = cookies?.filter((c) => c === 'tokenx-token');
+                    const cookieWithFakeToken = cookies?.filter((c) => c.includes('tokenx-token'));
                     if (!cookieWithFakeToken?.length) {
                         res.writeHead(401);
                         res.end();
@@ -49,19 +50,6 @@ async function startLabs(server) {
                     }
                     const accessToken = cookieWithFakeToken[0].split('=')[1];
                     proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
-                    if (req.body) {
-                        let bodyData = JSON.stringify(req.body);
-                        proxyReq.setHeader('Content-Type', 'application/json');
-                        proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-                        proxyReq.write(bodyData);
-                    }
-                },
-                changeOrigin: true,
-                proxyTimeout: 30000,
-                secure: true,
-                logLevel: 'info',
-                onError: (err, req, res) => {
-                    logger.error('error in proxy', err, req, res);
                 },
             })
         );

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -56,6 +56,19 @@ async function startLabs(server) {
                 onError: (err, req, res) => {
                     logger.error('error in proxy', err, req, res);
                 },
+                configure: (proxy) => {
+                    proxy.on('proxyReq', (proxyReq, req, res) => {
+                        const cookies = req.headers?.cookie?.split(';');
+                        const cookieWithFakeToken = cookies?.filter((c) => c === 'tokenx-token');
+                        if (!cookieWithFakeToken?.length) {
+                            res.writeHead(401);
+                            res.end();
+                            return;
+                        }
+                        const accessToken = cookieWithFakeToken[0].split('=')[1];
+                        proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
+                    });
+                },
             })
         );
 

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -99,7 +99,6 @@ async function startLabs(server) {
         );
         server.use('/logout', (req, res) => {
             res.clearCookie('tokenx-token');
-            res.clearCookie('aad-token');
             res.redirect('/');
         });
 

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -38,7 +38,7 @@ async function startLabs(server) {
         server.use(
             '/api',
             createProxyMiddleware({
-                target: 'http://tiltak-refusjon-api-labs',
+                target: 'http://tiltak-refusjon-api-labs/api',
                 changeOrigin: true,
                 on: {
                     proxyReq: (proxyReq, req, res, options) => {

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -19,15 +19,15 @@ async function startLabs(server) {
 
         // setup sane defaults for CORS and HTTP headers
         // server.use(helmet());
-        server.use(
-            cors({
-                allowedHeaders: ['sessionId', 'Content-Type'],
-                exposedHeaders: ['sessionId'],
-                origin: '*',
-                methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-                preflightContinue: false,
-            })
-        );
+        // server.use(
+        //     cors({
+        //         allowedHeaders: ['sessionId', 'Content-Type'],
+        //         exposedHeaders: ['sessionId'],
+        //         origin: '*',
+        //         methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+        //         preflightContinue: false,
+        //     })
+        // );
 
         // setup routes
         server.get('/isAlive', (req, res) => res.send('Alive'));

--- a/server/src/labs.js
+++ b/server/src/labs.js
@@ -18,7 +18,7 @@ async function startLabs(server) {
         server.use(express.urlencoded({ extended: true }));
 
         // setup sane defaults for CORS and HTTP headers
-        server.use(helmet());
+        //server.use(helmet());
         server.use(
             cors({
                 allowedHeaders: ['sessionId', 'Content-Type'],


### PR DESCRIPTION
En oppgradering av backenden har fjernet støtte for
"authtoken-cookies", så proxyen bør sende inn token
i authorization-header.

En fordel med denne endringen er at backenden ikke
lenger må forholde seg til både arbeidsgiver og
saksbehandler-tokenet ved tilgangssjekk, som potensielt
kan føre til merkelige feil hvor feks en beslutter blir antatt
å være en arbeidsgiver når man er logget inn i begge
tjenester.

En oppgradering av http-proxy-middleware hadde også
to breaking changes:
* vi må eksplisitt peke mot riktig path i target-feltet
* onProxyReq er flyttet til {on:{proxyReq: ...}}